### PR TITLE
Docker-compose web (apach2/nginx) with redirect from http to https

### DIFF
--- a/Docker-compose-web-srv-https-redirect/SyncFldr/centos-nginx/Dockerfile
+++ b/Docker-compose-web-srv-https-redirect/SyncFldr/centos-nginx/Dockerfile
@@ -1,0 +1,15 @@
+FROM centos:8.4.2105
+
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*; \
+ sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*; \
+ dnf install -y epel-release nginx; \
+ mkdir -p /usr/share/nginx/test-domain/  ;\
+ mkdir -p /opt/cert
+
+EXPOSE 80
+EXPOSE 433
+
+COPY test-domain.conf /etc/nginx/conf.d/ 
+COPY ./mycert /opt/cert
+ 
+ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/Docker-compose-web-srv-https-redirect/SyncFldr/centos-nginx/test-domain.conf
+++ b/Docker-compose-web-srv-https-redirect/SyncFldr/centos-nginx/test-domain.conf
@@ -1,0 +1,45 @@
+server {
+        listen 80;
+        listen [::]:80;
+
+        server_name test-domain;
+
+        return 301 https://test-domain:44301/;
+
+        root /usr/share/nginx/test-domain/;
+        
+        index index.html;
+
+        location /files {
+                alias /usr/share/nginx/test-domain/my-files-folder-for-alias;
+        }
+
+        location / {
+                try_files $uri $uri/ =404;
+        }
+}
+
+server {
+        listen 433 ssl http2;
+        listen [::]:433 ssl http2;
+
+        server_name test-domain;
+
+        ssl_certificate "/opt/cert/selfsigned.crt";
+        ssl_certificate_key "/opt/cert/selfsigned.key";
+        
+        #allow connections only with protocols TLSv1.2 TLSv1.3 
+        #there recomendation to use only TLSv1.2 TLSv1.3 from 2020, because previous versions of SSL and TLS protocols are outdated   
+        ssl_protocols TLSv1.2 TLSv1.3;
+
+        root /usr/share/nginx/test-domain/;
+        
+        index index.html;
+
+        location /files {
+                alias /usr/share/nginx/test-domain/my-files-folder-for-alias;
+        }
+
+        location / {
+                try_files $uri $uri/ =404;
+        }

--- a/Docker-compose-web-srv-https-redirect/SyncFldr/debian-apache2/Dockerfile
+++ b/Docker-compose-web-srv-https-redirect/SyncFldr/debian-apache2/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:22.10
+
+RUN apt-get update -y; \
+    apt-get install -y apt-utils; \
+    apt-get install -y apache2; \
+    apt-get install -y apache2-utils; \
+    apt-get clean;  \
+    mkdir -p /opt/cert 
+
+EXPOSE 80
+EXPOSE 443
+
+COPY ./mycert/ /opt/cert
+COPY test-domain.conf /etc/apache2/sites-available/
+
+RUN a2enmod ssl; \
+    a2ensite test-domain.conf ; \ 
+    a2dissite 000-default.conf
+
+CMD ["apache2ctl", "-D", "FOREGROUND"]

--- a/Docker-compose-web-srv-https-redirect/SyncFldr/debian-apache2/test-domain.conf
+++ b/Docker-compose-web-srv-https-redirect/SyncFldr/debian-apache2/test-domain.conf
@@ -1,0 +1,28 @@
+<VirtualHost *:80>
+    ServerAdmin admin@test-domain
+    ServerName test-domain
+
+    Redirect permanent / https://test-domain:44302/
+
+    DocumentRoot /var/www/test-domain
+    CustomLog /var/log/apache2/access.log combined
+    ErrorLog /var/log/apache2/error.log
+</VirtualHost>
+
+<VirtualHost *:433>
+    ServerAdmin admin@test-domain
+    ServerName test-domain
+    DocumentRoot /var/www/test-domain
+
+    CustomLog /var/log/apache2/access.log combined
+    ErrorLog /var/log/apache2/error.log
+
+    SSLEngine on
+
+    #remove old protocols from avalible protocols, to allow use only TLSv1.2 and TLSv1.3  
+    SSLProtocol all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
+    
+    SSLCertificateFile /opt/cert/selfsigned.crt
+    SSLCertificateKeyFile /opt/cert/selfsigned.key
+
+</VirtualHost>

--- a/Docker-compose-web-srv-https-redirect/SyncFldr/docker-compose.yaml
+++ b/Docker-compose-web-srv-https-redirect/SyncFldr/docker-compose.yaml
@@ -1,0 +1,22 @@
+version: "3.9"
+
+services:
+    nginx-on-centos:
+        build: centos-nginx/
+        container_name: nginx-tst
+        ports:
+            - "8091:80"
+            - "4331:433"
+        volumes:
+            - /home/vagrant/shared-folder:/usr/share/nginx/test-domain/
+            - /home/vagrant/log/nginx:/var/log/nginx/
+
+    apache-on-debian:
+        build: debian-apache2/
+        container_name: apache2-tst
+        ports:
+            - "8092:80"
+            - "4332:433"
+        volumes:
+            - /home/vagrant/shared-folder:/var/www/test-domain
+            - /home/vagrant/log/apache2:/var/log/apache2

--- a/Docker-compose-web-srv-https-redirect/SyncFldr/index.html
+++ b/Docker-compose-web-srv-https-redirect/SyncFldr/index.html
@@ -1,0 +1,1 @@
+<h1>Test-File-docker-compose</h1>

--- a/Docker-compose-web-srv-https-redirect/SyncFldr/rm-docker-cont-img-vol.sh
+++ b/Docker-compose-web-srv-https-redirect/SyncFldr/rm-docker-cont-img-vol.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# stop all running containers
+docker stop $(docker ps -aq)
+
+# remove all stopped containers
+docker rm $(docker ps -aq)
+
+
+# remove all images
+docker rmi $(docker images -q)
+
+# remove all stray volumes if any
+docker volume rm $(docker volume ls -q)

--- a/Docker-compose-web-srv-https-redirect/SyncFldr/test-docker-cmd-bsh.sh
+++ b/Docker-compose-web-srv-https-redirect/SyncFldr/test-docker-cmd-bsh.sh
@@ -1,0 +1,44 @@
+cd /SyncFldr
+
+# -------------------------------------------------------------------
+# Debian-apache2
+# -------------------------------------------------------------------
+
+docker build -t my-deb-apache2:1.0 ./Debian-apache2
+
+docker images
+
+docker run --name mydebapache2 -d -p 8080:80 my-deb-apache2:1.0
+
+docker stop mydebapache2
+
+docker rm mydebapache2
+
+docker image rm my-deb-apache2:1.0
+
+# -------------------------------------------------------------------
+# CentOS-nginx
+# -------------------------------------------------------------------
+
+
+docker build -t my-centos-nginx:1.0 ./CentOS-nginx
+
+docker run --name mycentosnginx -d -p 8080:80 my-centos-nginx:1.0
+
+docker stop mycentosnginx
+
+docker rm mycentosnginx
+
+docker image rm my-centos-nginx:1.0
+
+# -------------------------------------------------------------------
+#  docker compose
+# -------------------------------------------------------------------
+
+cp /SyncFldr/index.html ~/shared-folder-volume/
+
+docker-compose up -d
+
+docker-compose ps
+
+docker-compose down

--- a/Docker-compose-web-srv-https-redirect/Vagrantfile
+++ b/Docker-compose-web-srv-https-redirect/Vagrantfile
@@ -1,0 +1,28 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+
+  config.vm.box = "bento-ub2204-bb" # локальный basebox ubuntu2204
+  config.vm.box_check_update = false
+
+  config.vm.define "srv1" do |srv1|
+    srv1.vm.provider "virtualbox" do |vb|
+          vb.name = "vm_srv1_doker"
+          vb.memory = "4096"
+          vb.cpus = 4
+        end
+        
+    srv1.vm.hostname = "srv1-doker"
+
+    srv1.vm.provision "shell", path: "provision.sh"
+    
+    #srv1.vm.network "private_network", ip: "192.168.100.41" #, bridge: 'Intel(R) Dual Band Wireless-AC 3165'
+    
+    srv1.vm.network "public_network", ip: "192.168.50.41", bridge: 'Intel(R) Dual Band Wireless-AC 3165'
+
+    srv1.vm.synced_folder "SyncFldr/", "/SyncFldr" 
+
+  end
+
+end

--- a/Docker-compose-web-srv-https-redirect/provision.sh
+++ b/Docker-compose-web-srv-https-redirect/provision.sh
@@ -1,0 +1,23 @@
+sudo apt-get update -y
+
+sudo apt-get install needrestart -y
+
+sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a NEEDRESTART_SUSPEND=1 apt-get upgrade -y
+
+sudo apt install apt-transport-https ca-certificates curl software-properties-common -y
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable" -y
+
+apt-cache policy docker-ce
+
+sudo apt install docker-ce -y
+
+sudo apt install docker-compose -y
+
+sudo usermod -aG docker vagrant
+
+mkdir /home/vagrant/shared-folder
+
+cp /SyncFldr/index.html /home/vagrant/shared-folder/


### PR DESCRIPTION
Docker-compose web (apach2/nginx) with redirect from http to https

also in config files alowed only TLS 1.2/1.3 protocols to connect to web-servers.